### PR TITLE
[WIP] res.send(new String("test")) sends JSON

### DIFF
--- a/test/res.send.js
+++ b/test/res.send.js
@@ -245,6 +245,21 @@ describe('res', function(){
     })
   })
 
+  describe('.send(String)', function(){
+    it('should send as text/plain', function(done){
+      var app = express();
+
+      app.use(function(req, res){
+        res.send(new String('tobi'));
+      });
+
+      request(app)
+      .get('/')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200, 'tobi', done)
+    })
+  })
+  
   describe('when the request method is HEAD', function(){
     it('should ignore the body', function(done){
       var app = express();


### PR DESCRIPTION
If you do `res.send(new String("test"))` the expected behaviour is: `test`, but you get `"test"`, since typeof String is "object".

I am working on a PR to fix this,
